### PR TITLE
Remove accent from 'Αποσύνδεση'

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
             password: 'Κωδικός χρήστη',
             sign_in: 'Εισοδος',
             sign_in_error: 'Η ταυτοποίηση απέτυχε, προσπαθήστε ξανά',
-            logout: 'Αποσύνδεση',
+            logout: 'Αποσυνδεση',
         },
         notification: {
             updated: 'Η εγγραφή ανανεώθηκε',


### PR DESCRIPTION
In v2 (react-admin), this is needed, see why:

![image](https://user-images.githubusercontent.com/7850073/36878397-7aac777e-1dc7-11e8-8582-171ef2a83f1e.png)
